### PR TITLE
List additional subdomains in the service list

### DIFF
--- a/riptide_proxy/__main__.py
+++ b/riptide_proxy/__main__.py
@@ -23,7 +23,7 @@ def print_version():
     echo(f"riptide_proxy: {pkg_resources.get_distribution('riptide_proxy').version}")
 
 
-@click.command()
+@click.command(name="riptide_proxy")
 @click.option('--user', '-u', default=os.environ.get('SUDO_USER'),
               help='Only on POSIX systems when running as root: '
                    'Specify user configuration to use. Ignored otherwise. '
@@ -94,3 +94,7 @@ def main(user, loglevel, version=False):
             https_port=system_config["proxy"]["ports"]["https"],
             ssl_options=ssl_options
         )
+
+
+if __name__ == "__main__":
+    main()

--- a/riptide_proxy/tpl/service_list.html
+++ b/riptide_proxy/tpl/service_list.html
@@ -5,7 +5,12 @@
         {% if "port" in service %}
             {% set has_service = True %}
             <li {% if service_statuses[service['$name']] %}class="started"{% end %}>
-                {{ service['$name'] }}: <a href="//{{ service.domain() }}">//{{ service.domain() }}</a>
+                {{ service['$name'] }}: <ul>
+                <li><a href="//{{ service.domain() }}">//{{ service.domain() }}</a></li>
+                {% for subdomain, additional_domain in service.additional_domains().items() %}
+                    <li><a href="//{{ additional_domain }}">//{{ additional_domain }}</a></li>
+                {% end %}
+                </ul>
             </li>
         {% end %}
     {% end %}

--- a/riptide_proxy/tpl/styles.css
+++ b/riptide_proxy/tpl/styles.css
@@ -49,7 +49,7 @@ body > div {
   list-style: none;
 }
 
-.service-list li::before {
+.service-list > li::before {
   content: "\2022";
   color: red;
   font-weight: bold;
@@ -57,7 +57,7 @@ body > div {
   width: 1em;
   margin-left: -1em;
 }
-.service-list li.started::before {
+.service-list > li.started::before {
     color: darkgreen;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     ],
     entry_points='''
         [console_scripts]
-        riptide_proxy=riptide_proxy.main:main
+        riptide_proxy=riptide_proxy.__main__:main
     ''',
 )


### PR DESCRIPTION
This PR allows the service list page to show all accessible domains for services, including additional subdomains which were added in a different PR.

The services now use a list of links to reflect these changes:
![image](https://user-images.githubusercontent.com/109692091/226613064-3bfaf30e-9595-4405-8c56-62a2e7d777b2.png)

Additionally I adjusted the main script of the module a bit, so it can not only be ran with the script but also be called as a python module.

---

Depends on theCapypara/riptide-lib#45