### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/riptide_proxy/__main__.py
+++ b/riptide_proxy/__main__.py
@@ -1,6 +1,6 @@
 import click
 import logging
-import pkg_resources
+from importlib.metadata import version
 from click import ClickException, echo
 from tempfile import TemporaryDirectory
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(LOGGER_NAME)
 
 def print_version():
     echo(f"riptide_lib: {get_riptide_version_raw()}")
-    echo(f"riptide_proxy: {pkg_resources.get_distribution('riptide_proxy').version}")
+    echo(f"riptide_proxy: {version('riptide-proxy')}")
 
 
 @click.command(name="riptide_proxy")

--- a/riptide_proxy/resources.py
+++ b/riptide_proxy/resources.py
@@ -1,6 +1,14 @@
 """template file management"""
-import pkg_resources
+import atexit
+import importlib.resources
+
+from contextlib import ExitStack
 
 
 def get_resources():
-    return pkg_resources.resource_filename(__name__, 'tpl')
+    file_manager = ExitStack()
+    atexit.register(file_manager.close)
+    package_name = __name__.split(".")[0]
+    ref = importlib.resources.files(package_name) / 'tpl'
+    path = file_manager.enter_context(importlib.resources.as_file(ref))
+    return path


### PR DESCRIPTION
Since `pkg_resources` has been deprecated in favor of `importlib` this PR replaces the old API with the new one.

As a reference the following migration guides were used:
- [importlib.metadata](https://importlib-metadata.readthedocs.io/en/latest/migration.html)
- [importlib.resources](https://importlib-resources.readthedocs.io/en/latest/migration.html)