### PR TITLE
WebSocket: Support binary and text messages based on type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riptide-proxy"
-version = "0.9.0"
+version = "0.9.1"
 description = "Tool to manage development environments for web applications using containers - HTTP and WebSocket Reverse Proxy Server"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/riptide_proxy/server/websocket/others.py
+++ b/riptide_proxy/server/websocket/others.py
@@ -97,7 +97,7 @@ class ProxyWebsocketHandler(websocket.WebSocketHandler):
                 logger.debug(f"WebSocket Proxy ({self.project['name']}): received msg (server)")
                 if msg is None:
                     break
-                await self.write_message(msg, binary=True)
+                await self.write_message(msg, binary=isinstance(msg, bytes))
                 logger.debug(f"WebSocket Proxy ({self.project['name']}): write msg (client)")
 
         # Start backend read/write loop
@@ -112,7 +112,7 @@ class ProxyWebsocketHandler(websocket.WebSocketHandler):
     def on_message(self, message):
         # Send message to backend
         logger.debug(f"WebSocket Proxy ({self.project['name']}): received msg (client)")
-        self.conn.write_message(message, binary=True)
+        self.conn.write_message(message, binary=isinstance(message, bytes))
         logger.debug(f"WebSocket Proxy ({self.project['name']}): write msg (server)")
 
     def on_close(self, code=None, reason=None):


### PR DESCRIPTION
Previously we changed all websocket messages to be binary instead of text. However this breaks some other apps.
We can actually know if the message is text or binary just by looking on the Python type of the message.